### PR TITLE
Refac/embed edit

### DIFF
--- a/src/main/java/com/htmake/htbot/discord/commands/battle/action/BattleResultAction.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/battle/action/BattleResultAction.java
@@ -43,7 +43,7 @@ public class BattleResultAction {
         JSONObject monsterLoot = getMonsterLoot(monsterId);
 
         if (monsterLoot == null) {
-            errorUtil.sendError(event.getMessage(), "전투", "보상을 획득하지 못했습니다.");
+            errorUtil.sendError(event.getHook(), "전투", "보상을 획득하지 못했습니다.");
             return;
         }
 
@@ -53,7 +53,7 @@ public class BattleResultAction {
             boolean levelUp = response.getBody().getObject().getBoolean("levelUp");
             requestSuccess(event, monsterLoot, levelUp);
         } else {
-            errorUtil.sendError(event.getMessage(), "전투", "보상을 획득하지 못했습니다.");
+            errorUtil.sendError(event.getHook(), "전투", "보상을 획득하지 못했습니다.");
         }
     }
 
@@ -89,7 +89,7 @@ public class BattleResultAction {
         String levelUpMessage = levelUpCheck(playerId, levelUp);
         MessageEmbed embed = buildEmbed(monsterLoot, getItemList, levelUpMessage);
 
-        event.getMessage().editMessageEmbeds(embed)
+        event.getHook().editOriginalEmbeds(embed)
                 .setActionRow(
                         Button.success("dungeon-next", "전진하기"),
                         Button.danger("dungeon-close", "돌아가기")

--- a/src/main/java/com/htmake/htbot/discord/commands/battle/action/MonsterAttackAction.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/battle/action/MonsterAttackAction.java
@@ -51,12 +51,16 @@ public class MonsterAttackAction {
     private int skillAttack(ButtonInteractionEvent event, PlayerStatus playerStatus, MonsterStatus monsterStatus) {
         String message = monsterStatus.getName() + "의 " + monsterStatus.getSkillName() + "!";
         battleUtil.updateSituation(event.getUser().getId(), message);
+        battleUtil.editEmbed(event, playerStatus, monsterStatus);
+
         return Math.max(0, monsterStatus.getSkillDamage() - playerStatus.getDefence());
     }
 
     private int normalAttack(ButtonInteractionEvent event, PlayerStatus playerStatus, MonsterStatus monsterStatus) {
         String message = monsterStatus.getName() + "의 공격.";
         battleUtil.updateSituation(event.getUser().getId(), message);
+        battleUtil.editEmbed(event, playerStatus, monsterStatus);
+
         return Math.max(0, monsterStatus.getDamage() - playerStatus.getDefence());
     }
 

--- a/src/main/java/com/htmake/htbot/discord/commands/battle/event/BattleSkillButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/battle/event/BattleSkillButtonEvent.java
@@ -60,7 +60,7 @@ public class BattleSkillButtonEvent {
         String playerId = event.getUser().getId();
 
         if (!playerStatusCache.containsKey(playerId)) {
-            errorUtil.sendError(event.getMessage(), "전투", "스킬을 불러오지 못했습니다.");
+            errorUtil.sendError(event.getHook(), "전투", "스킬을 불러오지 못했습니다.");
             return;
         }
 
@@ -118,7 +118,7 @@ public class BattleSkillButtonEvent {
         String playerId = event.getUser().getId();
 
         if (!playerStatusCache.containsKey(playerId) || !monsterStatusCache.containsKey(playerId)) {
-            errorUtil.sendError(event.getMessage(), "전투", "스킬을 불러오지 못했습니다.");
+            errorUtil.sendError(event.getHook(), "전투", "정보를 불러오지 못했습니다.");
             return;
         }
 
@@ -129,10 +129,12 @@ public class BattleSkillButtonEvent {
         PlayerSkillStatus usedSkill = playerSkill.get(number);
 
         if (usedSkill == null) {
+            errorUtil.sendError(event.getHook(), "스킬 사용", "스킬 등록을 해주세요.");
             return;
         }
 
         if (playerStatus.getMana() < usedSkill.getMana()) {
+            errorUtil.sendError(event.getHook(), "스킬 사용", "마나가 부족합니다.");
             return;
         }
 
@@ -140,13 +142,14 @@ public class BattleSkillButtonEvent {
 
         String message = event.getUser().getName() + "의 " + usedSkill.getName() + ".";
         battleUtil.updateSituation(playerId, message);
+        battleUtil.editEmbed(event, playerStatus, monsterStatus);
 
         int skillDamage = skillDamage(playerStatus, monsterStatus, usedSkill.getValue());
+        monsterStatus.setHealth(Math.max(0, monsterStatus.getHealth() - skillDamage));
 
         message = skillDamage + "의 데미지를 입혔다.";
         battleUtil.updateSituation(playerId, message);
-
-        monsterStatus.setHealth(Math.max(0, monsterStatus.getHealth() - skillDamage));
+        battleUtil.editEmbed(event, playerStatus, monsterStatus);
 
         if (monsterStatus.getHealth() == 0) {
             monsterKillAction.execute(event, playerStatus, monsterStatus);

--- a/src/main/java/com/htmake/htbot/discord/commands/battle/util/BattleUtil.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/battle/util/BattleUtil.java
@@ -77,10 +77,10 @@ public class BattleUtil {
                 .addField(":boom: 치명타 확률", playerStatus.getCriticalChance() + "%", true)
                 .addField(":boom: 치명타 데미지", playerStatus.getCriticalDamage() + "%", true)
 
-                .setFooter("" + embed.getFooter().getText())
+                .setFooter(embed.getFooter().getText())
                 .build();
 
-        event.getMessage().editMessageEmbeds(newEmbed).queue();
+        event.getHook().editOriginalEmbeds(newEmbed).queue();
     }
 
     public void removeCurrentBattleCache(String playerId) {

--- a/src/main/java/com/htmake/htbot/discord/commands/dungeon/event/DungeonCloseButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/dungeon/event/DungeonCloseButtonEvent.java
@@ -48,12 +48,11 @@ public class DungeonCloseButtonEvent {
 
             if (response.getStatus() == 200) {
                 requestSuccess(event);
+                dungeonStatusCache.remove(playerId);
             } else {
-                errorUtil.sendError(event.getMessage(), "던전 퇴장", "던전 퇴장에 실패하였습니다.");
+                errorUtil.sendError(event.getHook(), "던전 퇴장", "던전 퇴장에 실패하였습니다.");
             }
         }
-
-        dungeonStatusCache.remove(playerId);
     }
 
     private HttpResponse<JsonNode> request(List<GetItem> getItemList, String playerId) {
@@ -74,7 +73,7 @@ public class DungeonCloseButtonEvent {
                 .setDescription("던전에서 퇴장하였습니다.")
                 .build();
 
-        event.getMessage().editMessageComponents(Collections.emptyList()).queue();
-        event.getMessage().editMessageEmbeds(embed).queue();
+        event.getHook().editOriginalComponents(Collections.emptyList()).queue();
+        event.getHook().editOriginalEmbeds(embed).queue();
     }
 }

--- a/src/main/java/com/htmake/htbot/discord/commands/dungeon/event/DungeonEntrySelectEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/dungeon/event/DungeonEntrySelectEvent.java
@@ -47,7 +47,7 @@ public class DungeonEntrySelectEvent {
 
             requestSuccess(event, playerObject, dungeonObject);
         } else {
-            errorUtil.sendError(event.getMessage(), "던전 입장", "던전에 입장할 수 없습니다.");
+            errorUtil.sendError(event.getHook(), "던전 입장", "던전에 입장할 수 없습니다.");
         }
     }
 
@@ -83,7 +83,7 @@ public class DungeonEntrySelectEvent {
 
         MessageEmbed embed = dungeonUtil.buildEmbed(dungeonTitle, dungeonMonster, dungeonPlayer, event.getUser().getName());
 
-        event.getMessage().editMessageEmbeds(embed)
+        event.getHook().editOriginalEmbeds(embed)
                 .setActionRow(
                         Button.success("battle-attack", "공격"),
                         Button.primary("battle-skill-open", "스킬"),

--- a/src/main/java/com/htmake/htbot/discord/commands/dungeon/event/NextDungeonEntryButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/dungeon/event/NextDungeonEntryButtonEvent.java
@@ -31,7 +31,8 @@ public class NextDungeonEntryButtonEvent {
         String playerId = event.getUser().getId();
 
         if (!dungeonStatusCache.containsKey(playerId)) {
-            errorUtil.sendError(event.getMessage(), "던전 입장", "던전 입장에 실패했습니다.");
+            errorUtil.sendError(event.getHook(), "던전 입장", "던전 입장에 실패했습니다.");
+            return;
         }
 
         DungeonStatus dungeonStatus = dungeonStatusCache.get(playerId);
@@ -53,7 +54,7 @@ public class NextDungeonEntryButtonEvent {
 
         MessageEmbed embed = dungeonUtil.buildEmbed(dungeonTitle, dungeonMonster, dungeonPlayer, event.getUser().getName());
 
-        event.getMessage().editMessageEmbeds(embed)
+        event.getHook().editOriginalEmbeds(embed)
                 .setActionRow(
                         Button.success("battle-attack", "공격"),
                         Button.primary("battle-skill-open", "스킬"),

--- a/src/main/java/com/htmake/htbot/discord/commands/inventory/event/InventoryButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/inventory/event/InventoryButtonEvent.java
@@ -36,7 +36,7 @@ public class InventoryButtonEvent {
         Inventory inventory = inventoryCache.get(event.getUser().getId());
 
         if (inventory == null) {
-            errorUtil.sendError(event.getMessage(), "인벤토리", "인벤토리를 찾을 수 없습니다.");
+            errorUtil.sendError(event.getHook(), "인벤토리", "인벤토리를 찾을 수 없습니다.");
             return;
         }
 
@@ -55,7 +55,7 @@ public class InventoryButtonEvent {
         actionRowList.add(actionRowButton);
         actionRowList.add(actionRowSelect);
 
-        event.getMessage().editMessageEmbeds(newEmbed)
+        event.getHook().editOriginalEmbeds(newEmbed)
                 .setComponents(actionRowList)
                 .queue();
     }

--- a/src/main/java/com/htmake/htbot/discord/commands/inventory/event/InventorySelectEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/inventory/event/InventorySelectEvent.java
@@ -36,7 +36,7 @@ public class InventorySelectEvent {
         Inventory inventory = inventoryCache.get(event.getUser().getId());
 
         if (inventory == null) {
-            errorUtil.sendError(event.getMessage(), "인벤토리", "인벤토리를 찾을 수 없습니다.");
+            errorUtil.sendError(event.getHook(), "인벤토리", "인벤토리를 찾을 수 없습니다.");
             return;
         }
 
@@ -58,7 +58,7 @@ public class InventorySelectEvent {
         actionRowList.add(actionRowButton);
         actionRowList.add(actionRowSelect);
 
-        event.getMessage().editMessageEmbeds(newEmbed)
+        event.getHook().editOriginalEmbeds(newEmbed)
                 .setComponents(actionRowList)
                 .queue();
     }

--- a/src/main/java/com/htmake/htbot/discord/commands/player/event/PlayerJoinButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/player/event/PlayerJoinButtonEvent.java
@@ -33,7 +33,7 @@ public class PlayerJoinButtonEvent {
         if (response.getStatus() == 200) {
             requestSuccess(event);
         } else {
-            errorUtil.sendError(event.getMessage(), "게임 가입", "게임 가입을 이용할 수 없습니다. 잠시 후 다시 이용해주세요.");
+            errorUtil.sendError(event.getHook(), "게임 가입", "게임 가입을 이용할 수 없습니다. 잠시 후 다시 이용해주세요.");
         }
     }
 
@@ -54,7 +54,7 @@ public class PlayerJoinButtonEvent {
                 .setDescription("게임 가입에 성공했습니다!")
                 .build();
 
-        event.getMessage().editMessageComponents(Collections.emptyList()).queue();
-        event.getMessage().editMessageEmbeds(embed).queue();
+        event.getHook().editOriginalComponents(Collections.emptyList()).queue();
+        event.getHook().editOriginalEmbeds(embed).queue();
     }
 }

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/event/QuestCompleteButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/event/QuestCompleteButtonEvent.java
@@ -29,7 +29,7 @@ public class QuestCompleteButtonEvent {
         if (response.getStatus() == 200) {
             requestSuccess(event);
         } else {
-            errorUtil.sendError(event.getMessage(), "퀘스트를 완료하지 못했습니다.", "목표를 달성하고 다시 시도해 주세요.");
+            errorUtil.sendError(event.getHook(), "퀘스트를 완료하지 못했습니다.", "목표를 달성하고 다시 시도해 주세요.");
         }
     }
 
@@ -46,8 +46,7 @@ public class QuestCompleteButtonEvent {
                 .setDescription("다음 퀘스트를 확인해 주세요.")
                 .build();
 
-        event.getMessage().editMessageComponents(Collections.emptyList()).queue();
-
-        event.getMessage().editMessageEmbeds(embed).queue();
+        event.getHook().editOriginalComponents(Collections.emptyList()).queue();
+        event.getHook().editOriginalEmbeds(embed).queue();
     }
 }

--- a/src/main/java/com/htmake/htbot/discord/commands/skill/event/RegisterSkillButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/skill/event/RegisterSkillButtonEvent.java
@@ -38,7 +38,7 @@ public class RegisterSkillButtonEvent {
             JSONArray skillArray = response.getBody().getObject().getJSONArray("skillResponseList");
             requestSuccess(event, skillArray, number);
         } else {
-            errorUtil.sendError(event.getMessage(), "스킬 등록", "스킬 목록을 불러오지 못했습니다.");
+            errorUtil.sendError(event.getHook(), "스킬 등록", "스킬 목록을 불러오지 못했습니다.");
         }
     }
 
@@ -53,7 +53,7 @@ public class RegisterSkillButtonEvent {
         MessageEmbed embed = buildEmbed(skillList);
         StringSelectMenu menu = buildMenu(skillList, number);
 
-        event.getMessage().editMessageEmbeds(embed)
+        event.getHook().editOriginalEmbeds(embed)
                 .setActionRow(menu)
                 .queue();
     }

--- a/src/main/java/com/htmake/htbot/discord/commands/skill/event/RegisterSkillSelectEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/skill/event/RegisterSkillSelectEvent.java
@@ -34,7 +34,7 @@ public class RegisterSkillSelectEvent {
         if (response.getStatus() == 200) {
             requestSuccess(event);
         } else {
-            errorUtil.sendError(event.getMessage(), "스킬 등록", "스킬을 등록 할 수 없습니다.");
+            errorUtil.sendError(event.getHook(), "스킬 등록", "스킬을 등록 할 수 없습니다.");
         }
     }
 
@@ -57,7 +57,7 @@ public class RegisterSkillSelectEvent {
                 .setDescription("스킬 등록에 성공했습니다!")
                 .build();
 
-        event.getMessage().editMessageComponents(Collections.emptyList()).queue();
-        event.getMessage().editMessageEmbeds(embed).queue();
+        event.getHook().editOriginalComponents(Collections.emptyList()).queue();
+        event.getHook().editOriginalEmbeds(embed).queue();
     }
 }

--- a/src/main/java/com/htmake/htbot/discord/util/ErrorUtil.java
+++ b/src/main/java/com/htmake/htbot/discord/util/ErrorUtil.java
@@ -1,12 +1,11 @@
 package com.htmake.htbot.discord.util;
 
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.InteractionHook;
 
 import java.awt.*;
-import java.util.Collections;
 
 public class ErrorUtil {
 
@@ -15,10 +14,10 @@ public class ErrorUtil {
         event.replyEmbeds(embed).queue();
     }
 
-    public void sendError(Message message, String title, String description) {
+    public void sendError(InteractionHook hook, String title, String description) {
         MessageEmbed embed = buildEmbed(title, description);
-        message.editMessageComponents(Collections.emptyList()).queue();
-        message.editMessageEmbeds(embed).queue();
+        hook.setEphemeral(true);
+        hook.sendMessageEmbeds(embed).queue();
     }
 
     private MessageEmbed buildEmbed(String title, String description) {


### PR DESCRIPTION
- 임베드 수정 방식을 getMessage()를 이용했던 기존 방식에서 getHook()로 변경.

- 전투 현황을 한 번에 수정하던 기존 방식에서  4번에 걸쳐 수정하도록 변경.

- 버튼 및 셀렉트 이벤트에서 오류 발생 시 원래 기존 임베드를 수정하여 오류를 띄웠지만, 그렇게 하게 되면 전투 중 갑작스럽게 전투가 끊기는 등 여러가지 상황이 나올 수 있어 본인만 볼 수 있는 오류 임베드를 새로 보내는 식으로 변경. 

- resolved #43