### PR TITLE
기절 상태 처리 구현

### DIFF
--- a/src/main/java/com/htmake/htbot/discord/commands/battle/event/BattleSkillButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/battle/event/BattleSkillButtonEvent.java
@@ -130,26 +130,28 @@ public class BattleSkillButtonEvent {
             return;
         }
 
-        String message = event.getUser().getName() + "의 " + usedSkill.getName() + ".";
-        battleUtil.updateSituation(playerId, message);
-        battleUtil.editEmbed(event, playerStatus, monsterStatus, "start");
-
         BasicSkill basicSkill = usedSkill.getBasicSkill();
         List<Pair<String, SkillType>> resultList = basicSkill.execute(playerData, monsterData);
 
+        String secondMessage = "";
+
         for (Pair<String, SkillType> result : resultList) {
             switch (result.getSecond()) {
-                case ATTACK -> message = result.getFirst() + "의 데미지를 입혔다.";
-                case HEAL -> message = result.getFirst() + "의 체력을 회복했다.";
-                case BUFF -> message = result.getFirst() + " 효과를 얻었다.";
-                case DEBUFF -> message = result.getFirst() + " 효과를 입혔다.";
+                case ATTACK -> secondMessage = result.getFirst() + "의 데미지를 입혔다.";
+                case HEAL -> secondMessage = result.getFirst() + "의 체력을 회복했다.";
+                case BUFF -> secondMessage = result.getFirst() + " 효과를 얻었다.";
+                case DEBUFF -> secondMessage = result.getFirst() + " 효과를 입혔다.";
                 case NOT_ENOUGH_MANA -> {
                     errorUtil.sendError(event.getHook(), "스킬 사용", "마나가 부족합니다.");
                     return;
                 }
             }
 
-            battleUtil.updateSituation(playerId, message);
+            String firstMessage = event.getUser().getName() + "의 " + usedSkill.getName() + ".";
+            battleUtil.updateSituation(playerId, firstMessage);
+            battleUtil.editEmbed(event, playerStatus, monsterStatus, "start");
+
+            battleUtil.updateSituation(playerId, secondMessage);
             battleUtil.editEmbed(event, playerStatus, monsterStatus, "progress");
         }
 


### PR DESCRIPTION
- 기절 상태를 가지고 있는 플레이어와 몬스터가 일정 확률로 공격에 실패하도록 하는 기능 구현
- 스킬 사용 시 마나 검사를 임베드 수정보다 늦게 해서 마나가 부족한 경우에 임베드 수정이 진행 중에 멈추는 오류 해결