### PR TITLE
스킬 사용 시 전투 현황이 이상하게 뜨는 버그 수정

### DIFF
--- a/src/main/java/com/htmake/htbot/discord/commands/battle/event/BattleSkillButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/battle/event/BattleSkillButtonEvent.java
@@ -131,27 +131,27 @@ public class BattleSkillButtonEvent {
         }
 
         BasicSkill basicSkill = usedSkill.getBasicSkill();
-        List<Pair<String, SkillType>> resultList = basicSkill.execute(playerData, monsterData);
 
-        String secondMessage = "";
+        if (!basicSkill.manaCheck(playerData)) {
+            errorUtil.sendError(event.getHook(), "스킬 사용", "마나가 부족합니다.");
+            return;
+        }
+
+        String message = event.getUser().getName() + "의 " + usedSkill.getName() + ".";
+        battleUtil.updateSituation(playerId, message);
+        battleUtil.editEmbed(event, playerStatus, monsterStatus, "start");
+
+        List<Pair<String, SkillType>> resultList = basicSkill.execute(playerData, monsterData);
 
         for (Pair<String, SkillType> result : resultList) {
             switch (result.getSecond()) {
-                case ATTACK -> secondMessage = result.getFirst() + "의 데미지를 입혔다.";
-                case HEAL -> secondMessage = result.getFirst() + "의 체력을 회복했다.";
-                case BUFF -> secondMessage = result.getFirst() + " 효과를 얻었다.";
-                case DEBUFF -> secondMessage = result.getFirst() + " 효과를 입혔다.";
-                case NOT_ENOUGH_MANA -> {
-                    errorUtil.sendError(event.getHook(), "스킬 사용", "마나가 부족합니다.");
-                    return;
-                }
+                case ATTACK -> message = result.getFirst() + "의 데미지를 입혔다.";
+                case HEAL -> message = result.getFirst() + "의 체력을 회복했다.";
+                case BUFF -> message = result.getFirst() + " 효과를 얻었다.";
+                case DEBUFF -> message = result.getFirst() + " 효과를 입혔다.";
             }
 
-            String firstMessage = event.getUser().getName() + "의 " + usedSkill.getName() + ".";
-            battleUtil.updateSituation(playerId, firstMessage);
-            battleUtil.editEmbed(event, playerStatus, monsterStatus, "start");
-
-            battleUtil.updateSituation(playerId, secondMessage);
+            battleUtil.updateSituation(playerId, message);
             battleUtil.editEmbed(event, playerStatus, monsterStatus, "progress");
         }
 

--- a/src/main/java/com/htmake/htbot/discord/skillAction/BasicSkill.java
+++ b/src/main/java/com/htmake/htbot/discord/skillAction/BasicSkill.java
@@ -21,4 +21,8 @@ public class BasicSkill {
     public List<Pair<String, SkillType>> execute(PlayerData playerData, MonsterData monsterData) {
         return strategy.execute(playerData, monsterData);
     }
+
+    public boolean manaCheck(PlayerData playerData) {
+        return strategy.manaCheck(playerData);
+    }
 }

--- a/src/main/java/com/htmake/htbot/discord/skillAction/skill/SkillStrategy.java
+++ b/src/main/java/com/htmake/htbot/discord/skillAction/skill/SkillStrategy.java
@@ -2,7 +2,6 @@ package com.htmake.htbot.discord.skillAction.skill;
 
 import com.htmake.htbot.discord.commands.battle.data.MonsterData;
 import com.htmake.htbot.discord.commands.battle.data.PlayerData;
-import com.htmake.htbot.discord.commands.battle.data.status.extend.PlayerStatus;
 import com.htmake.htbot.discord.skillAction.condition.Condition;
 import com.htmake.htbot.discord.skillAction.condition.extend.buff.Buff;
 import com.htmake.htbot.discord.commands.battle.data.status.BasicStatus;
@@ -17,6 +16,8 @@ import java.util.Map;
 public interface SkillStrategy {
 
     List<Pair<String, SkillType>> execute(PlayerData playerData, MonsterData monsterData);
+
+    boolean manaCheck(PlayerData playerData);
 
     default int critical(int damage, int criticalDamage, int criticalChance) {
         RandomGenerator random = new MersenneTwister();
@@ -35,18 +36,5 @@ public interface SkillStrategy {
             Buff existsBuff = (Buff) conditionMap.get(id);
             existsBuff.unapply(status, originalStatus);
         }
-    }
-
-    default boolean manaCheck(PlayerStatus playerStatus, int manaCost, List<Pair<String, SkillType>> resultList) {
-        int mana = playerStatus.getMana();
-
-        if (mana < manaCost) {
-            resultList.add(new Pair<>("Not enough mana", SkillType.NOT_ENOUGH_MANA));
-            return true;
-        }
-
-        playerStatus.setMana(mana - manaCost);
-
-        return false;
     }
 }

--- a/src/main/java/com/htmake/htbot/discord/skillAction/skill/impl/AbstractSkillStrategy.java
+++ b/src/main/java/com/htmake/htbot/discord/skillAction/skill/impl/AbstractSkillStrategy.java
@@ -19,15 +19,21 @@ public abstract class AbstractSkillStrategy implements SkillStrategy {
     @Override
     public List<Pair<String, SkillType>> execute(PlayerData playerData, MonsterData monsterData) {
         List<Pair<String, SkillType>> resultList = new ArrayList<>();
+        applySkill(playerData, monsterData, resultList);
+        return resultList;
+    }
 
+    @Override
+    public boolean manaCheck(PlayerData playerData) {
         PlayerStatus playerStatus = playerData.getPlayerStatus();
+        int mana = playerStatus.getMana();
 
-        if (manaCheck(playerStatus, getManaCost(), resultList)) {
-            return resultList;
+        if (mana < getManaCost()) {
+            return false;
         }
 
-        applySkill(playerData, monsterData, resultList);
+        playerStatus.setMana(mana - getManaCost());
 
-        return resultList;
+        return true;
     }
 }

--- a/src/main/java/com/htmake/htbot/discord/skillAction/skills/archer/class4/S2401.java
+++ b/src/main/java/com/htmake/htbot/discord/skillAction/skills/archer/class4/S2401.java
@@ -31,16 +31,25 @@ public class S2401 extends AbstractSkillStrategy {
     @Override
     public List<Pair<String, SkillType>> execute(PlayerData playerData, MonsterData monsterData) {
         List<Pair<String, SkillType>> resultList = new ArrayList<>();
+        setBuffedState(playerData);
+        applySkill(playerData, monsterData, resultList);
+        return resultList;
+    }
+
+    @Override
+    public boolean manaCheck(PlayerData playerData) {
+        PlayerStatus playerStatus = playerData.getPlayerStatus();
+        int mana = playerStatus.getMana();
 
         setBuffedState(playerData);
 
-        if (manaCheck(playerData.getPlayerStatus(), getManaCost(), resultList)) {
-            return resultList;
+        if (mana < getManaCost()) {
+            return false;
         }
 
-        applySkill(playerData, monsterData, resultList);
+        playerStatus.setMana(mana - getManaCost());
 
-        return resultList;
+        return true;
     }
 
     @Override

--- a/src/main/java/com/htmake/htbot/discord/skillAction/skills/archer/class4/S2402.java
+++ b/src/main/java/com/htmake/htbot/discord/skillAction/skills/archer/class4/S2402.java
@@ -33,16 +33,25 @@ public class S2402 extends AbstractSkillStrategy {
     @Override
     public List<Pair<String, SkillType>> execute(PlayerData playerData, MonsterData monsterData) {
         List<Pair<String, SkillType>> resultList = new ArrayList<>();
+        setBuffedState(playerData);
+        applySkill(playerData, monsterData, resultList);
+        return resultList;
+    }
+
+    @Override
+    public boolean manaCheck(PlayerData playerData) {
+        PlayerStatus playerStatus = playerData.getPlayerStatus();
+        int mana = playerStatus.getMana();
 
         setBuffedState(playerData);
 
-        if (manaCheck(playerData.getPlayerStatus(), getManaCost(), resultList)) {
-            return resultList;
+        if (mana < getManaCost()) {
+            return false;
         }
 
-        applySkill(playerData, monsterData, resultList);
+        playerStatus.setMana(mana - getManaCost());
 
-        return resultList;
+        return true;
     }
 
     @Override

--- a/src/main/java/com/htmake/htbot/discord/skillAction/type/SkillType.java
+++ b/src/main/java/com/htmake/htbot/discord/skillAction/type/SkillType.java
@@ -3,5 +3,4 @@ package com.htmake.htbot.discord.skillAction.type;
 public enum SkillType {
 
     ATTACK, HEAL, BUFF, DEBUFF,
-    NOT_ENOUGH_MANA
 }


### PR DESCRIPTION
- 전에 마나 검사를 event에서 skill class내부로 옮기면서 전투 현황을 업데이트하는 부분도 같이 수정이 됐는데 그러다가 이런 버그가 발생했다.
- 그래서 마나 검사를 skill class에서 그대로 하되, event 내에서 마나 검사를 따로 하도록 변경하였다.