### PR TITLE
퀘스트 대화 기능 구현

### DIFF
--- a/src/main/java/com/htmake/htbot/discord/commands/quest/QuestCommand.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/QuestCommand.java
@@ -1,6 +1,7 @@
 package com.htmake.htbot.discord.commands.quest;
 
 import com.htmake.htbot.discord.commands.quest.event.QuestCompleteButtonEvent;
+import com.htmake.htbot.discord.commands.quest.event.QuestDialogueButtonEvent;
 import com.htmake.htbot.discord.commands.quest.event.QuestSlashEvent;
 import com.htmake.htbot.discord.util.ErrorUtil;
 import com.htmake.htbot.discord.util.MessageUtil;
@@ -19,6 +20,8 @@ public class QuestCommand extends ListenerAdapter {
 
     private final QuestCompleteButtonEvent questCompleteButtonEvent;
 
+    private final QuestDialogueButtonEvent questDialogueButtonEvent;
+
     private final ErrorUtil errorUtil;
     private final MessageUtil messageUtil;
 
@@ -26,6 +29,8 @@ public class QuestCommand extends ListenerAdapter {
         this.questSlashEvent = new QuestSlashEvent();
 
         this.questCompleteButtonEvent = new QuestCompleteButtonEvent();
+
+        this.questDialogueButtonEvent = new QuestDialogueButtonEvent();
 
         this.errorUtil = new ErrorUtil();
         this.messageUtil = new MessageUtil();
@@ -57,6 +62,11 @@ public class QuestCommand extends ListenerAdapter {
 
             if (componentList.get(1).equals("complete")) {
                 questCompleteButtonEvent.execute(event);
+            }
+
+            switch (componentList.get(1)) {
+                case "complete" -> questCompleteButtonEvent.execute(event);
+                case "dialogue" -> questDialogueButtonEvent.execute(event, componentList.get(2));
             }
         }
     }

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/action/QuestCompleteAction.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/action/QuestCompleteAction.java
@@ -1,0 +1,52 @@
+package com.htmake.htbot.discord.commands.quest.action;
+
+import com.htmake.htbot.discord.util.ErrorUtil;
+import com.htmake.htbot.global.unirest.HttpClient;
+import com.htmake.htbot.global.unirest.impl.HttpClientImpl;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import kotlin.Pair;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+
+import java.awt.*;
+import java.util.Collections;
+
+public class QuestCompleteAction {
+
+    private final HttpClient httpClient;
+    private final ErrorUtil errorUtil;
+
+    public QuestCompleteAction() {
+        this.httpClient = new HttpClientImpl();
+        this.errorUtil = new ErrorUtil();
+    }
+
+    public void execute(ButtonInteractionEvent event) {
+        HttpResponse<JsonNode> response = request(event.getUser().getId());
+
+        if (response.getStatus() == 200) {
+            requestSuccess(event);
+        } else {
+            errorUtil.sendError(event.getHook(), "퀘스트", "퀘스트를 완료할 수 없습니다.");
+        }
+    }
+
+    private HttpResponse<JsonNode> request(String playerId) {
+        String endPoint = "/quest/progress/{player_id}";
+        Pair<String, String> routeParam = new Pair<>("player_id", playerId);
+        return httpClient.sendPostRequest(endPoint, routeParam);
+    }
+
+    public void requestSuccess(ButtonInteractionEvent event) {
+        MessageEmbed embed = new EmbedBuilder()
+                .setColor(Color.GREEN)
+                .setTitle(":tada: 퀘스트")
+                .setDescription("퀘스트를 완료했습니다.\n다음 퀘스트를 확인해 주세요.")
+                .build();
+
+        event.getHook().editOriginalComponents(Collections.emptyList()).queue();
+        event.getHook().editOriginalEmbeds(embed).queue();
+    }
+}

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/action/QuestDetailAction.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/action/QuestDetailAction.java
@@ -1,0 +1,147 @@
+package com.htmake.htbot.discord.commands.quest.action;
+
+import com.htmake.htbot.discord.util.ErrorUtil;
+import com.htmake.htbot.discord.util.FormatUtil;
+import com.htmake.htbot.global.custom.interaction.enums.EventType;
+import com.htmake.htbot.global.custom.interaction.factory.InteractionEventFactory;
+import com.htmake.htbot.global.custom.interaction.wrapper.InteractionEventWrapper;
+import com.htmake.htbot.global.unirest.HttpClient;
+import com.htmake.htbot.global.unirest.impl.HttpClientImpl;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import kotlin.Pair;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.awt.*;
+
+public class QuestDetailAction {
+
+    private final HttpClient httpClient;
+    private final ErrorUtil errorUtil;
+
+    private User user;
+
+    public QuestDetailAction() {
+        this.httpClient = new HttpClientImpl();
+        this.errorUtil = new ErrorUtil();
+
+        this.user = null;
+    }
+
+    public void execute(SlashCommandInteractionEvent event) {
+        this.user = event.getUser();
+        InteractionEventWrapper eventWrapper = InteractionEventFactory.createWrapper(event);
+        execute(eventWrapper);
+    }
+
+    public void execute(ButtonInteractionEvent event) {
+        this.user = event.getUser();
+        InteractionEventWrapper eventWrapper = InteractionEventFactory.createWrapper(event);
+        execute(eventWrapper);
+    }
+
+    private void execute(InteractionEventWrapper event) {
+        HttpResponse<JsonNode> response = request();
+
+        if (response.getStatus() == 200) {
+            JSONObject questObject = response.getBody().getObject();
+            requestSuccess(event, questObject);
+        } else {
+            EventType eventType = event.getEventType();
+            if (eventType.equals(EventType.SLASH)) {
+                errorUtil.sendError(event.getSlashEvent(), "퀘스트를 불러올 수 없습니다.", "잠시 후 다시 이용해주세요.");
+            } else {
+                errorUtil.sendError(event.getButtonEvent().getHook(), "퀘스트를 불러올 수 없습니다.", "잠시 후 다시 이용해주세요.");
+            }
+        }
+    }
+
+    private HttpResponse<JsonNode> request() {
+        String endPoint = "/quest/{player_id}";
+        Pair<String, String> routeParam = new Pair<>("player_id", user.getId());
+        return httpClient.sendGetRequest(endPoint, routeParam);
+    }
+
+    private void requestSuccess(InteractionEventWrapper event, JSONObject questObject) {
+        MessageEmbed embed = buildEmbed(questObject);
+
+        Button completeButton = Button.primary("quest-complete", "완료").asDisabled();
+        if (validTargetQuantity(questObject)) {
+            completeButton = Button.primary("quest-complete", "완료").asEnabled();
+        }
+
+        event.replyEmbed(embed)
+                .setActionRow(
+                        completeButton,
+                        Button.danger("cancel", "닫기")
+                )
+                .queue();
+    }
+
+    private MessageEmbed buildEmbed(JSONObject questObject) {
+        String profileUrl = user.getAvatarUrl() != null ? user.getAvatarUrl() : user.getDefaultAvatarUrl();
+
+        return new EmbedBuilder()
+                .setColor(Color.GREEN)
+                .setAuthor(user.getName(), null, profileUrl)
+                .setTitle(":scroll: 퀘스트")
+                .addField(questObject.getString("title"), questObject.getString("description"), false)
+                .addField(":dart: 목표", targetFormat(questObject), false)
+                .addField(":purse: 보상", rewardFormat(questObject), false)
+                .build();
+    }
+
+    private String targetFormat(JSONObject questObject) {
+        JSONArray targetArray = questObject.getJSONArray("targetList");
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < targetArray.length(); i++) {
+            JSONObject targetObject = targetArray.getJSONObject(i);
+            sb.append(targetObject.getString("name")).append(" (")
+                    .append(targetObject.getInt("currentQuantity")).append("/")
+                    .append(targetObject.getInt("requiredQuantity")).append(")\n");
+        }
+
+        return sb.toString();
+    }
+
+    private String rewardFormat(JSONObject questObject) {
+        JSONArray rewardArray = questObject.getJSONArray("rewardList");
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(FormatUtil.decimalFormat(questObject.getInt("gold"))).append(" 골드\n")
+                .append(FormatUtil.decimalFormat(questObject.getInt("exp"))).append(" 경험치\n");
+
+        for (int i = 0; i < rewardArray.length(); i++) {
+            JSONObject rewardObject = rewardArray.getJSONObject(i);
+            sb.append(rewardObject.getString("name")).append(" ")
+                    .append(rewardObject.getInt("quantity")).append("개\n");
+        }
+
+        return sb.toString();
+    }
+
+    private boolean validTargetQuantity(JSONObject questObject) {
+        JSONArray targetArray = questObject.getJSONArray("targetList");
+
+        for (int i = 0; i < targetArray.length(); i++) {
+            JSONObject targetObject = targetArray.getJSONObject(i);
+
+            int requiredQuantity = targetObject.getInt("requiredQuantity");
+            int currentQuantity = targetObject.getInt("currentQuantity");
+
+            if (currentQuantity < requiredQuantity) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/action/QuestDetailAction.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/action/QuestDetailAction.java
@@ -66,7 +66,7 @@ public class QuestDetailAction {
     private HttpResponse<JsonNode> request() {
         String endPoint = "/quest/{player_id}";
         Pair<String, String> routeParam = new Pair<>("player_id", user.getId());
-        return httpClient.sendGetRequest(endPoint, routeParam);
+        return httpClient.sendPostRequest(endPoint, routeParam);
     }
 
     private void requestSuccess(InteractionEventWrapper event, JSONObject questObject) {

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/action/QuestDialogueAction.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/action/QuestDialogueAction.java
@@ -1,0 +1,147 @@
+package com.htmake.htbot.discord.commands.quest.action;
+
+import com.htmake.htbot.discord.commands.quest.cache.QuestDialogueCache;
+import com.htmake.htbot.discord.commands.quest.data.DialogueData;
+import com.htmake.htbot.discord.commands.quest.data.QuestDialogueData;
+import com.htmake.htbot.discord.commands.quest.util.QuestUtil;
+import com.htmake.htbot.discord.util.ErrorUtil;
+import com.htmake.htbot.domain.quest.enums.Trigger;
+import com.htmake.htbot.global.cache.CacheFactory;
+import com.htmake.htbot.global.generics.LimitedCapacityDeque;
+import com.htmake.htbot.global.custom.interaction.enums.EventType;
+import com.htmake.htbot.global.custom.interaction.factory.InteractionEventFactory;
+import com.htmake.htbot.global.custom.interaction.wrapper.InteractionEventWrapper;
+import com.htmake.htbot.global.unirest.records.RequestParam;
+import com.htmake.htbot.global.unirest.records.RouteParam;
+import com.htmake.htbot.global.unirest.HttpClient;
+import com.htmake.htbot.global.unirest.impl.HttpClientImpl;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuestDialogueAction {
+
+    private final HttpClient httpClient;
+    private final ErrorUtil errorUtil;
+    private final QuestUtil questUtil;
+
+    private final QuestDialogueCache questDialogueCache;
+
+    private User user;
+
+    public QuestDialogueAction() {
+        this.httpClient = new HttpClientImpl();
+        this.errorUtil = new ErrorUtil();
+        this.questUtil = new QuestUtil();
+
+        this.questDialogueCache = CacheFactory.questDialogueCache;
+    }
+
+    public void execute(SlashCommandInteractionEvent event) {
+        this.user = event.getUser();
+        InteractionEventWrapper eventWrapper = InteractionEventFactory.createWrapper(event);
+        execute(eventWrapper, Trigger.START);
+    }
+
+    public void execute(ButtonInteractionEvent event) {
+        this.user = event.getUser();
+        InteractionEventWrapper eventWrapper = InteractionEventFactory.createWrapper(event);
+        execute(eventWrapper, Trigger.END);
+    }
+
+    private void execute(InteractionEventWrapper event, Trigger trigger) {
+        HttpResponse<JsonNode> response = request(trigger);
+
+        if (response.getStatus() == 200) {
+            JSONObject questDialogueObject = response.getBody().getObject();
+            requestSuccess(event, trigger, questDialogueObject);
+        } else {
+            if (event.getEventType().equals(EventType.SLASH)) {
+                errorUtil.sendError(event.getSlashEvent(), "퀘스트를 불러올 수 없습니다.", "잠시 후 다시 이용해주세요.");
+            } else {
+                errorUtil.sendError(event.getButtonEvent().getHook(), "퀘스트를 불러올 수 없습니다.", "잠시 후 다시 이용해주세요.");
+            }
+        }
+    }
+
+    private HttpResponse<JsonNode> request(Trigger trigger) {
+        String endPoint = "/quest/dialogue/{player_id}";
+        RouteParam routeParam = new RouteParam("player_id", user.getId());
+        RequestParam requestParam = new RequestParam("trigger", trigger.toString());
+        return httpClient.sendGetRequest(endPoint, routeParam, requestParam);
+    }
+
+    private void requestSuccess(InteractionEventWrapper event, Trigger trigger, JSONObject questDialogueObject) {
+        QuestDialogueData questDialogueData = saveCache(trigger, questDialogueObject);
+        LimitedCapacityDeque<DialogueData> ongoingDialogue = questDialogueData.getOngoingDialogue();
+
+        MessageEmbed embed = buildEmbed(ongoingDialogue);
+
+        event.replyEmbed(embed)
+                .setActionRow(
+                        Button.primary("quest-dialogue-before", "이전").asDisabled(),
+                        Button.primary("quest-dialogue-next", "다음"),
+                        Button.danger("cancel", "닫기")
+                )
+                .queue();
+    }
+
+    private QuestDialogueData saveCache(Trigger trigger, JSONObject questDialogueObject) {
+        List<DialogueData> dialogueList = toDialougeList(questDialogueObject);
+        LimitedCapacityDeque<DialogueData> ongoingDialogue = new LimitedCapacityDeque<>(6);
+        ongoingDialogue.addFirst(dialogueList.get(0));
+
+        QuestDialogueData questDialogueData = QuestDialogueData.builder()
+                .dialogueList(dialogueList)
+                .ongoingDialogue(ongoingDialogue)
+                .trigger(trigger)
+                .build();
+
+        questDialogueCache.put(user.getId(), questDialogueData);
+
+        return questDialogueData;
+    }
+
+    private List<DialogueData> toDialougeList(JSONObject scriptObject) {
+        List<DialogueData> dialogueList = new ArrayList<>();
+        JSONArray dialogueArray = scriptObject.getJSONArray("dialogueList");
+
+        for (int i = 0; i < dialogueArray.length(); i++) {
+            JSONObject dialogueObject = dialogueArray.getJSONObject(i);
+
+            DialogueData dialogue = DialogueData.builder()
+                    .character(dialogueObject.getString("character"))
+                    .dialogue(dialogueObject.getString("dialogue"))
+                    .sequence(dialogueObject.getInt("sequence"))
+                    .build();
+
+            dialogue.setPlayerName(user.getName());
+
+            dialogueList.add(dialogue);
+        }
+
+        return dialogueList;
+    }
+
+    private MessageEmbed buildEmbed(LimitedCapacityDeque<DialogueData> ongoingDialogue) {
+        String profileUrl = user.getAvatarUrl() != null ? user.getAvatarUrl() : user.getDefaultAvatarUrl();
+
+        return new EmbedBuilder()
+                .setColor(Color.GREEN)
+                .setAuthor(user.getName(), null, profileUrl)
+                .setTitle(":scroll: 퀘스트")
+                .setDescription(questUtil.convertDialogue(ongoingDialogue.findAll()))
+                .build();
+    }
+}

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/cache/QuestDialogueCache.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/cache/QuestDialogueCache.java
@@ -1,0 +1,29 @@
+package com.htmake.htbot.discord.commands.quest.cache;
+
+import com.htmake.htbot.discord.commands.quest.data.QuestDialogueData;
+import com.htmake.htbot.global.cache.CacheManager;
+
+public class QuestDialogueCache {
+
+    private final CacheManager<String, QuestDialogueData> cache;
+
+    public QuestDialogueCache() {
+        this.cache = new CacheManager<>();
+    }
+
+    public void put(String key, QuestDialogueData questDialogueData) {
+        cache.put(key, questDialogueData);
+    }
+
+    public QuestDialogueData get(String key) {
+        return cache.get(key);
+    }
+
+    public boolean containsKey(String key) {
+        return cache.containsKey(key);
+    }
+
+    public void remove(String key) {
+        cache.remove(key);
+    }
+}

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/data/DialogueData.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/data/DialogueData.java
@@ -1,0 +1,24 @@
+package com.htmake.htbot.discord.commands.quest.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DialogueData {
+
+    private String character;
+
+    private String dialogue;
+
+    private int sequence;
+
+    public void setPlayerName(String playerName) {
+        if (character.equals("{player}")) character = playerName;
+        dialogue = dialogue.replace("{player}", playerName);
+    }
+}

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/data/QuestDialogueData.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/data/QuestDialogueData.java
@@ -1,0 +1,23 @@
+package com.htmake.htbot.discord.commands.quest.data;
+
+import com.htmake.htbot.domain.quest.enums.Trigger;
+import com.htmake.htbot.global.generics.LimitedCapacityDeque;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuestDialogueData {
+
+    private List<DialogueData> dialogueList;
+
+    private LimitedCapacityDeque<DialogueData> ongoingDialogue;
+
+    private Trigger trigger;
+}

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/enums/QuestButtonType.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/enums/QuestButtonType.java
@@ -1,0 +1,10 @@
+package com.htmake.htbot.discord.commands.quest.enums;
+
+public enum QuestButtonType {
+
+    NEXT, BEFORE, CONFIRM;
+
+    public static QuestButtonType toEnum(String s) {
+        return QuestButtonType.valueOf(s.toUpperCase());
+    }
+}

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/event/QuestCompleteButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/event/QuestCompleteButtonEvent.java
@@ -1,52 +1,17 @@
 package com.htmake.htbot.discord.commands.quest.event;
 
-import com.htmake.htbot.discord.util.ErrorUtil;
-import com.htmake.htbot.global.unirest.HttpClient;
-import com.htmake.htbot.global.unirest.impl.HttpClientImpl;
-import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.JsonNode;
-import kotlin.Pair;
-import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.MessageEmbed;
+import com.htmake.htbot.discord.commands.quest.action.QuestDialogueAction;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
-
-import java.awt.*;
-import java.util.Collections;
 
 public class QuestCompleteButtonEvent {
 
-    private final HttpClient httpClient;
-    private final ErrorUtil errorUtil;
+    private final QuestDialogueAction questDialogueAction;
 
     public QuestCompleteButtonEvent() {
-        this.httpClient = new HttpClientImpl();
-        this.errorUtil = new ErrorUtil();
+        this.questDialogueAction = new QuestDialogueAction();
     }
 
     public void execute(ButtonInteractionEvent event) {
-        HttpResponse<JsonNode> response = request(event.getUser().getId());
-
-        if (response.getStatus() == 200) {
-            requestSuccess(event);
-        } else {
-            errorUtil.sendError(event.getHook(), "퀘스트를 완료하지 못했습니다.", "목표를 달성하고 다시 시도해 주세요.");
-        }
-    }
-
-    private HttpResponse<JsonNode> request(String playerId) {
-        String endPoint = "/quest/progress/{player_id}";
-        Pair<String, String> routeParam = new Pair<>("player_id", playerId);
-        return httpClient.sendPostRequest(endPoint, routeParam);
-    }
-
-    public void requestSuccess(ButtonInteractionEvent event) {
-        MessageEmbed embed = new EmbedBuilder()
-                .setColor(Color.GREEN)
-                .setTitle(":tada: 퀘스트를 완료했습니다.")
-                .setDescription("다음 퀘스트를 확인해 주세요.")
-                .build();
-
-        event.getHook().editOriginalComponents(Collections.emptyList()).queue();
-        event.getHook().editOriginalEmbeds(embed).queue();
+        questDialogueAction.execute(event);
     }
 }

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/event/QuestDialogueButtonEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/event/QuestDialogueButtonEvent.java
@@ -1,0 +1,136 @@
+package com.htmake.htbot.discord.commands.quest.event;
+
+import com.htmake.htbot.discord.commands.quest.action.QuestCompleteAction;
+import com.htmake.htbot.discord.commands.quest.action.QuestDetailAction;
+import com.htmake.htbot.discord.commands.quest.cache.QuestDialogueCache;
+import com.htmake.htbot.discord.commands.quest.data.DialogueData;
+import com.htmake.htbot.discord.commands.quest.data.QuestDialogueData;
+import com.htmake.htbot.discord.commands.quest.enums.QuestButtonType;
+import com.htmake.htbot.discord.commands.quest.util.QuestUtil;
+import com.htmake.htbot.discord.util.ErrorUtil;
+import com.htmake.htbot.domain.quest.enums.Trigger;
+import com.htmake.htbot.global.cache.CacheFactory;
+import com.htmake.htbot.global.generics.LimitedCapacityDeque;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuestDialogueButtonEvent {
+
+    private final ErrorUtil errorUtil;
+    private final QuestUtil questUtil;
+
+    private final QuestDetailAction questDetailAction;
+    private final QuestCompleteAction questCompleteAction;
+
+    private final QuestDialogueCache questDialogueCache;
+
+    public QuestDialogueButtonEvent() {
+        this.errorUtil = new ErrorUtil();
+        this.questUtil = new QuestUtil();
+
+        this.questDetailAction = new QuestDetailAction();
+        this.questCompleteAction = new QuestCompleteAction();
+
+        this.questDialogueCache = CacheFactory.questDialogueCache;
+    }
+
+    public void execute(ButtonInteractionEvent event, String type) {
+        QuestButtonType buttonType = QuestButtonType.toEnum(type);
+        String playerId = event.getUser().getId();
+
+        if (!questDialogueCache.containsKey(playerId)) {
+            errorUtil.sendError(event.getHook(), "퀘스트", "대화 내용을 불러올 수 없습니다.");
+        }
+
+        QuestDialogueData questDialogue = questDialogueCache.get(playerId);
+
+        switch (buttonType) {
+            case NEXT -> nextButton(event, questDialogue);
+            case BEFORE -> beforeButton(event, questDialogue);
+            case CONFIRM -> confirmButton(event, questDialogue);
+        }
+    }
+
+    private void nextButton(ButtonInteractionEvent event, QuestDialogueData questDialogue) {
+        MessageEmbed originalEmbed = event.getMessage().getEmbeds().get(0);
+        List<DialogueData> dialogueList = questDialogue.getDialogueList();
+        LimitedCapacityDeque<DialogueData> ongoingDialogue = questDialogue.getOngoingDialogue();
+
+        int sequence = ongoingDialogue.getLast().getSequence();
+        ongoingDialogue.addLast(dialogueList.get(sequence));
+
+        MessageEmbed newEmbed = buildEmbed(originalEmbed, ongoingDialogue);
+        List<Button> buttonList = new ArrayList<>();
+
+        buttonList.add(Button.primary("quest-dialogue-before", "이전"));
+
+        if (sequence == dialogueList.size() - 1) {
+            buttonList.add(Button.success("quest-dialogue-confirm", "완료"));
+        } else {
+            buttonList.add(Button.primary("quest-dialogue-next", "다음"));
+        }
+
+        buttonList.add(Button.danger("cancel", "닫기"));
+
+        event.getHook().editOriginalEmbeds(newEmbed)
+                .setComponents(ActionRow.of(buttonList))
+                .queue();
+    }
+
+    private void beforeButton(ButtonInteractionEvent event, QuestDialogueData questDialogue) {
+        MessageEmbed originalEmbed = event.getMessage().getEmbeds().get(0);
+        List<DialogueData> dialogueList = questDialogue.getDialogueList();
+        LimitedCapacityDeque<DialogueData> ongoingDialogue = questDialogue.getOngoingDialogue();
+
+        int firstSequence = ongoingDialogue.getFirst().getSequence();
+        int lastSequence = ongoingDialogue.getLast().getSequence();
+        int currentSize = ongoingDialogue.size();
+        int maxSize = ongoingDialogue.maxSize();
+
+        if (currentSize < maxSize) {
+            ongoingDialogue.removeLast();
+        } else {
+            ongoingDialogue.addFirst(dialogueList.get(firstSequence - 1));
+        }
+
+        MessageEmbed newEmbed = buildEmbed(originalEmbed, ongoingDialogue);
+        Button beforeButton = Button.primary("quest-dialogue-before", "이전");
+
+        if (lastSequence == 2) {
+            beforeButton = Button.primary("quest-dialogue-before", "이전").asDisabled();
+        }
+
+        event.getHook().editOriginalEmbeds(newEmbed)
+                .setActionRow(
+                        beforeButton,
+                        Button.primary("quest-dialogue-next", "다음"),
+                        Button.danger("cancel", "닫기")
+                )
+                .queue();
+    }
+
+    private MessageEmbed buildEmbed(MessageEmbed originalEmbed, LimitedCapacityDeque<DialogueData> ongoingDialogue) {
+        return new EmbedBuilder()
+                .setColor(originalEmbed.getColor())
+                .setAuthor(originalEmbed.getAuthor().getName(), null, originalEmbed.getAuthor().getIconUrl())
+                .setTitle(originalEmbed.getTitle())
+                .setDescription(questUtil.convertDialogue(ongoingDialogue.findAll()))
+                .build();
+    }
+
+    private void confirmButton(ButtonInteractionEvent event, QuestDialogueData questDialogue) {
+        Trigger trigger = questDialogue.getTrigger();
+
+        if (trigger.equals(Trigger.START)) {
+            questDetailAction.execute(event);
+        } else {
+            questCompleteAction.execute(event);
+        }
+    }
+}

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/event/QuestSlashEvent.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/event/QuestSlashEvent.java
@@ -1,124 +1,57 @@
 package com.htmake.htbot.discord.commands.quest.event;
 
+import com.htmake.htbot.discord.commands.quest.action.QuestDetailAction;
+import com.htmake.htbot.discord.commands.quest.action.QuestDialogueAction;
 import com.htmake.htbot.discord.util.ErrorUtil;
-import com.htmake.htbot.discord.util.FormatUtil;
 import com.htmake.htbot.global.unirest.HttpClient;
 import com.htmake.htbot.global.unirest.impl.HttpClientImpl;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import kotlin.Pair;
-import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import org.json.JSONArray;
 import org.json.JSONObject;
-
-import java.awt.*;
 
 public class QuestSlashEvent {
 
     private final HttpClient httpClient;
     private final ErrorUtil errorUtil;
 
+    private final QuestDetailAction questDetailAction;
+    private final QuestDialogueAction questDialogueAction;
+
     public QuestSlashEvent() {
         this.httpClient = new HttpClientImpl();
         this.errorUtil = new ErrorUtil();
+
+        this.questDetailAction = new QuestDetailAction();
+        this.questDialogueAction = new QuestDialogueAction();
     }
 
     public void execute(SlashCommandInteractionEvent event) {
         HttpResponse<JsonNode> response = request(event.getUser().getId());
-        
+
         if (response.getStatus() == 200) {
-            JSONObject questObject = response.getBody().getObject();
-            requestSuccess(event, questObject);
+            JSONObject checkObject = response.getBody().getObject();
+            requestSuccess(event, checkObject);
         } else {
-            errorUtil.sendError(event, "퀘스트를 불러올 수 없습니다.", "잠시 후 다시 이용해주세요.");
+            errorUtil.sendError(event, "퀘스트", "퀘스트를 불러올 수 없습니다.");
         }
     }
 
     private HttpResponse<JsonNode> request(String playerId) {
-        String endPoint = "/quest/{player_id}";
+        String endPoint = "/quest/dialogue/check/{player_id}";
         Pair<String, String> routeParam = new Pair<>("player_id", playerId);
         return httpClient.sendGetRequest(endPoint, routeParam);
     }
 
-    private void requestSuccess(SlashCommandInteractionEvent event, JSONObject questObject) {
-        MessageEmbed embed = buildEmbed(questObject, event.getUser());
+    private void requestSuccess(SlashCommandInteractionEvent event, JSONObject checkObject) {
+        boolean readDialogue = checkObject.getBoolean("readDialogue");
 
-        Button completeButton = Button.primary("quest-complete", "완료").asDisabled();
-
-        if (validTargetQuantity(questObject)) {
-            completeButton = Button.primary("quest-complete", "완료").asEnabled();
+        if (readDialogue) {
+            questDetailAction.execute(event);
+        } else {
+            questDialogueAction.execute(event);
         }
-
-        event.replyEmbeds(embed)
-                .addActionRow(
-                        completeButton,
-                        Button.danger("cancel", "닫기")
-                )
-                .queue();
-    }
-
-    private MessageEmbed buildEmbed(JSONObject questObject, User user) {
-        String profileUrl = user.getAvatarUrl() != null ? user.getAvatarUrl() : user.getDefaultAvatarUrl();
-
-        return new EmbedBuilder()
-                .setColor(Color.GREEN)
-                .setAuthor(user.getName(), null, profileUrl)
-                .setTitle(":scroll: 퀘스트")
-                .addField(questObject.getString("title"), questObject.getString("description"), false)
-                .addField(":dart: 목표", targetFormat(questObject), false)
-                .addField(":purse: 보상", rewardFormat(questObject), false)
-                .build();
-    }
-
-    private String targetFormat(JSONObject questObject) {
-        JSONArray targetArray = questObject.getJSONArray("targetList");
-        StringBuilder sb = new StringBuilder();
-
-        for (int i = 0; i < targetArray.length(); i++) {
-            JSONObject targetObject = targetArray.getJSONObject(i);
-            sb.append(targetObject.getString("name")).append(" (")
-                    .append(targetObject.getInt("currentQuantity")).append("/")
-                    .append(targetObject.getInt("requiredQuantity")).append(")\n");
-        }
-
-        return sb.toString();
-    }
-
-    private String rewardFormat(JSONObject questObject) {
-        JSONArray rewardArray = questObject.getJSONArray("rewardList");
-        StringBuilder sb = new StringBuilder();
-
-        sb.append(FormatUtil.decimalFormat(questObject.getInt("gold"))).append(" 골드\n")
-                .append(FormatUtil.decimalFormat(questObject.getInt("exp"))).append(" 경험치\n");
-
-        for (int i = 0; i < rewardArray.length(); i++) {
-            JSONObject rewardObject = rewardArray.getJSONObject(i);
-            sb.append(rewardObject.getString("name")).append(" ")
-                    .append(rewardObject.getInt("quantity")).append("개\n");
-        }
-
-        return sb.toString();
-    }
-
-    private boolean validTargetQuantity(JSONObject questObject) {
-        JSONArray targetArray = questObject.getJSONArray("targetList");
-
-        for (int i = 0; i < targetArray.length(); i++) {
-            JSONObject targetObject = targetArray.getJSONObject(i);
-
-            int requiredQuantity = targetObject.getInt("requiredQuantity");
-            int currentQuantity = targetObject.getInt("currentQuantity");
-
-            if (currentQuantity < requiredQuantity) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }
 

--- a/src/main/java/com/htmake/htbot/discord/commands/quest/util/QuestUtil.java
+++ b/src/main/java/com/htmake/htbot/discord/commands/quest/util/QuestUtil.java
@@ -1,0 +1,22 @@
+package com.htmake.htbot.discord.commands.quest.util;
+
+import com.htmake.htbot.discord.commands.quest.data.DialogueData;
+
+import java.util.List;
+
+public class QuestUtil {
+
+    public String convertDialogue(List<DialogueData> dialogueList) {
+        StringBuilder sb = new StringBuilder();
+
+        for (DialogueData dialogue : dialogueList) {
+            sb.append(dialogueFormat(dialogue)).append("\n\n");
+        }
+
+        return sb.toString();
+    }
+
+    private String dialogueFormat(DialogueData dialogue) {
+        return dialogue.getCharacter() + ": " + dialogue.getDialogue();
+    }
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/entity/MainQuest.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/entity/MainQuest.java
@@ -1,6 +1,7 @@
 package com.htmake.htbot.domain.quest.entity;
 
 import com.htmake.htbot.domain.quest.entity.reward.QuestReward;
+import com.htmake.htbot.domain.quest.entity.dialogue.QuestDialogue;
 import com.htmake.htbot.domain.quest.entity.target.misc.TargetMisc;
 import com.htmake.htbot.domain.quest.entity.target.monster.TargetMonster;
 import jakarta.persistence.*;
@@ -42,4 +43,7 @@ public class MainQuest {
 
     @OneToMany(mappedBy = "mainQuest", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<PlayerQuest> playerQuestList;
+
+    @OneToMany(mappedBy = "mainQuest", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<QuestDialogue> questDialogueList;
 }

--- a/src/main/java/com/htmake/htbot/domain/quest/entity/PlayerQuest.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/entity/PlayerQuest.java
@@ -3,6 +3,7 @@ package com.htmake.htbot.domain.quest.entity;
 import com.htmake.htbot.domain.player.entity.Player;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -24,8 +25,15 @@ public class PlayerQuest {
     @JoinColumn(name = "main_quest_id")
     private MainQuest mainQuest;
 
+    @Column(name = "read_dialogue")
+    @ColumnDefault("false")
+    private boolean readDialogue;
 
     public void setMainQuest(MainQuest mainQuest) {
         this.mainQuest = mainQuest;
+    }
+
+    public void setReadDialogue(boolean readDialogue) {
+        this.readDialogue = readDialogue;
     }
 }

--- a/src/main/java/com/htmake/htbot/domain/quest/entity/dialogue/QuestDialogue.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/entity/dialogue/QuestDialogue.java
@@ -1,0 +1,36 @@
+package com.htmake.htbot.domain.quest.entity.dialogue;
+
+import com.htmake.htbot.domain.quest.entity.MainQuest;
+import com.htmake.htbot.domain.quest.enums.Trigger;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestDialogue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "quest_dialogue_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "main_quest_id", nullable = false)
+    private MainQuest mainQuest;
+
+    @Column(name = "dialogue_character", nullable = false)
+    private String character;
+
+    @Column(name = "dialogue_text", nullable = false)
+    private String dialogue;
+
+    @Column(name = "dialogue_sequence", nullable = false)
+    private int sequence;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dialogue_trigger", nullable = false)
+    private Trigger trigger;
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/enums/Trigger.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/enums/Trigger.java
@@ -1,0 +1,6 @@
+package com.htmake.htbot.domain.quest.enums;
+
+public enum Trigger {
+
+    START, END
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/presentation/QuestController.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/presentation/QuestController.java
@@ -2,9 +2,9 @@ package com.htmake.htbot.domain.quest.presentation;
 
 import com.htmake.htbot.domain.quest.presentation.data.request.PlayerQuestMonsterQuantityRequest;
 import com.htmake.htbot.domain.quest.presentation.data.response.PlayerQuestInfoResponse;
-import com.htmake.htbot.domain.quest.service.PlayerQuestInfoService;
-import com.htmake.htbot.domain.quest.service.PlayerQuestMonsterQuantityService;
-import com.htmake.htbot.domain.quest.service.PlayerQuestProgressService;
+import com.htmake.htbot.domain.quest.presentation.data.response.QuestDialogueResponse;
+import com.htmake.htbot.domain.quest.presentation.data.response.ReadDialogueCheckResponse;
+import com.htmake.htbot.domain.quest.service.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,12 +17,29 @@ import org.springframework.web.bind.annotation.*;
 public class QuestController {
 
     private final PlayerQuestInfoService playerQuestInfoService;
+    private final ReadDialogueCheckService readDialogueCheckService;
+    private final QuestDialogueService questDialogueService;
     private final PlayerQuestProgressService playerQuestProgressService;
     private final PlayerQuestMonsterQuantityService playerQuestMonsterQuantityService;
 
-    @GetMapping("/{player_id}")
+    @PostMapping("/{player_id}")
     public ResponseEntity<PlayerQuestInfoResponse> quest(@PathVariable("player_id") String playerId) {
         PlayerQuestInfoResponse response = playerQuestInfoService.execute(playerId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/dialogue/check/{player_id}")
+    public ResponseEntity<ReadDialogueCheckResponse> readDialogueCheck(@PathVariable("player_id") String playerId) {
+        ReadDialogueCheckResponse response = readDialogueCheckService.execute(playerId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/dialogue/{player_id}")
+    public ResponseEntity<QuestDialogueResponse> questDialogue(
+            @PathVariable("player_id") String playerId,
+            @RequestParam("trigger") String trigger
+    ) {
+        QuestDialogueResponse response = questDialogueService.execute(playerId, trigger);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/htmake/htbot/domain/quest/presentation/data/response/DialogueDetailResponse.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/presentation/data/response/DialogueDetailResponse.java
@@ -1,0 +1,28 @@
+package com.htmake.htbot.domain.quest.presentation.data.response;
+
+import com.htmake.htbot.domain.quest.entity.dialogue.QuestDialogue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DialogueDetailResponse {
+
+    private String character;
+
+    private String dialogue;
+
+    private int sequence;
+
+    public static DialogueDetailResponse toResponse(QuestDialogue questDialogue) {
+        return DialogueDetailResponse.builder()
+                .character(questDialogue.getCharacter())
+                .dialogue(questDialogue.getDialogue())
+                .sequence(questDialogue.getSequence())
+                .build();
+    }
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/presentation/data/response/QuestDialogueResponse.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/presentation/data/response/QuestDialogueResponse.java
@@ -1,0 +1,17 @@
+package com.htmake.htbot.domain.quest.presentation.data.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuestDialogueResponse {
+
+    private List<DialogueDetailResponse> dialogueList;
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/presentation/data/response/ReadDialogueCheckResponse.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/presentation/data/response/ReadDialogueCheckResponse.java
@@ -1,0 +1,15 @@
+package com.htmake.htbot.domain.quest.presentation.data.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReadDialogueCheckResponse {
+
+    private boolean readDialogue;
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/repository/QuestDialogueRepository.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/repository/QuestDialogueRepository.java
@@ -1,0 +1,14 @@
+package com.htmake.htbot.domain.quest.repository;
+
+import com.htmake.htbot.domain.quest.entity.MainQuest;
+import com.htmake.htbot.domain.quest.entity.dialogue.QuestDialogue;
+import com.htmake.htbot.domain.quest.enums.Trigger;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuestDialogueRepository extends JpaRepository<QuestDialogue, Long> {
+
+    List<QuestDialogue> findByMainQuestAndTrigger(MainQuest m, Trigger t, Sort s);
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/service/QuestDialogueService.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/service/QuestDialogueService.java
@@ -1,0 +1,8 @@
+package com.htmake.htbot.domain.quest.service;
+
+import com.htmake.htbot.domain.quest.presentation.data.response.QuestDialogueResponse;
+
+public interface QuestDialogueService {
+
+    QuestDialogueResponse execute(String playerId, String trigger);
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/service/ReadDialogueCheckService.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/service/ReadDialogueCheckService.java
@@ -1,0 +1,8 @@
+package com.htmake.htbot.domain.quest.service;
+
+import com.htmake.htbot.domain.quest.presentation.data.response.ReadDialogueCheckResponse;
+
+public interface ReadDialogueCheckService {
+
+    ReadDialogueCheckResponse execute(String playerId);
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/service/impl/PlayerQuestInfoServiceImpl.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/service/impl/PlayerQuestInfoServiceImpl.java
@@ -18,14 +18,14 @@ import com.htmake.htbot.domain.quest.repository.PlayerTargetMonsterRepository;
 import com.htmake.htbot.domain.quest.service.PlayerQuestInfoService;
 import com.htmake.htbot.domain.quest.entity.MainQuest;
 import com.htmake.htbot.domain.quest.repository.MainQuestRepository;
-import com.htmake.htbot.global.annotation.ReadOnlyService;
+import com.htmake.htbot.global.annotation.TransactionalService;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@ReadOnlyService
+@TransactionalService
 @RequiredArgsConstructor
 public class PlayerQuestInfoServiceImpl implements PlayerQuestInfoService {
 
@@ -47,8 +47,12 @@ public class PlayerQuestInfoServiceImpl implements PlayerQuestInfoService {
         List<TargetResponse> targetResponseList = new ArrayList<>();
         targetMonster(playerId, mainQuest, targetResponseList);
         targetMisc(playerId, mainQuest, targetResponseList);
-
         List<QuestReward> questRewardList = mainQuest.getQuestRewardList();
+
+        if (!playerQuest.isReadDialogue()) {
+            playerQuest.setReadDialogue(true);
+            playerQuestRepository.save(playerQuest);
+        }
 
         return PlayerQuestInfoResponse.builder()
                 .title(mainQuest.getTitle())

--- a/src/main/java/com/htmake/htbot/domain/quest/service/impl/PlayerQuestMonsterQuantityServiceImpl.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/service/impl/PlayerQuestMonsterQuantityServiceImpl.java
@@ -30,6 +30,10 @@ public class PlayerQuestMonsterQuantityServiceImpl implements PlayerQuestMonster
         PlayerQuest playerQuest = playerQuestRepository.findByPlayerId(playerId)
                 .orElseThrow(NotFoundPlayerException::new);
 
+        if (!playerQuest.isReadDialogue()) {
+            return;
+        }
+
         Long progress = playerQuest.getMainQuest().getId();
 
         MainQuest mainQuest = mainQuestRepository.findById(progress)

--- a/src/main/java/com/htmake/htbot/domain/quest/service/impl/PlayerQuestProgressServiceImpl.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/service/impl/PlayerQuestProgressServiceImpl.java
@@ -63,6 +63,7 @@ public class PlayerQuestProgressServiceImpl implements PlayerQuestProgressServic
                         .orElseThrow(NotFoundQuestException::new);
 
         playerQuest.setMainQuest(newMainQuest);
+        playerQuest.setReadDialogue(false);
         questUtil.initialSet(player, newMainQuest);
         playerQuestRepository.save(playerQuest);
 

--- a/src/main/java/com/htmake/htbot/domain/quest/service/impl/QuestDialogueServiceImpl.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/service/impl/QuestDialogueServiceImpl.java
@@ -1,0 +1,47 @@
+package com.htmake.htbot.domain.quest.service.impl;
+
+import com.htmake.htbot.domain.quest.entity.MainQuest;
+import com.htmake.htbot.domain.quest.entity.PlayerQuest;
+import com.htmake.htbot.domain.quest.entity.dialogue.QuestDialogue;
+import com.htmake.htbot.domain.quest.enums.Trigger;
+import com.htmake.htbot.domain.quest.exception.NotFoundQuestException;
+import com.htmake.htbot.domain.quest.presentation.data.response.DialogueDetailResponse;
+import com.htmake.htbot.domain.quest.presentation.data.response.QuestDialogueResponse;
+import com.htmake.htbot.domain.quest.repository.PlayerQuestRepository;
+import com.htmake.htbot.domain.quest.repository.QuestDialogueRepository;
+import com.htmake.htbot.domain.quest.service.QuestDialogueService;
+import com.htmake.htbot.global.annotation.ReadOnlyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ReadOnlyService
+@RequiredArgsConstructor
+public class QuestDialogueServiceImpl implements QuestDialogueService {
+
+    private final PlayerQuestRepository playerQuestRepository;
+    private final QuestDialogueRepository questDialogueRepository;
+
+    @Override
+    public QuestDialogueResponse execute(String playerId, String trigger) {
+        PlayerQuest playerQuest = playerQuestRepository.findByPlayerId(playerId)
+                .orElseThrow(NotFoundQuestException::new);
+
+        MainQuest mainQuest = playerQuest.getMainQuest();
+        Trigger enumTrigger = Trigger.valueOf(trigger);
+        Sort sort = Sort.by(Sort.Direction.ASC, "sequence");
+
+        List<QuestDialogue> questDialogueList = questDialogueRepository
+                .findByMainQuestAndTrigger(mainQuest, enumTrigger, sort);
+
+        return QuestDialogueResponse.builder()
+                .dialogueList(
+                        questDialogueList.stream()
+                                .map(DialogueDetailResponse::toResponse)
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/htmake/htbot/domain/quest/service/impl/ReadDialogueCheckServiceImpl.java
+++ b/src/main/java/com/htmake/htbot/domain/quest/service/impl/ReadDialogueCheckServiceImpl.java
@@ -1,0 +1,26 @@
+package com.htmake.htbot.domain.quest.service.impl;
+
+import com.htmake.htbot.domain.quest.entity.PlayerQuest;
+import com.htmake.htbot.domain.quest.exception.NotFoundQuestException;
+import com.htmake.htbot.domain.quest.presentation.data.response.ReadDialogueCheckResponse;
+import com.htmake.htbot.domain.quest.repository.PlayerQuestRepository;
+import com.htmake.htbot.domain.quest.service.ReadDialogueCheckService;
+import com.htmake.htbot.global.annotation.ReadOnlyService;
+import lombok.RequiredArgsConstructor;
+
+@ReadOnlyService
+@RequiredArgsConstructor
+public class ReadDialogueCheckServiceImpl implements ReadDialogueCheckService {
+
+    private final PlayerQuestRepository playerQuestRepository;
+
+    @Override
+    public ReadDialogueCheckResponse execute(String playerId) {
+        PlayerQuest playerQuest = playerQuestRepository.findByPlayerId(playerId)
+                .orElseThrow(NotFoundQuestException::new);
+
+        return ReadDialogueCheckResponse.builder()
+                .readDialogue(playerQuest.isReadDialogue())
+                .build();
+    }
+}

--- a/src/main/java/com/htmake/htbot/global/cache/CacheFactory.java
+++ b/src/main/java/com/htmake/htbot/global/cache/CacheFactory.java
@@ -7,6 +7,7 @@ import com.htmake.htbot.discord.commands.battle.cache.PlayerDataCache;
 import com.htmake.htbot.discord.commands.battle.cache.SituationCache;
 import com.htmake.htbot.discord.commands.global.cache.MessageCache;
 import com.htmake.htbot.discord.commands.inventory.cache.InventoryCache;
+import com.htmake.htbot.discord.commands.quest.cache.QuestDialogueCache;
 import com.htmake.htbot.discord.commands.shop.cache.BossShopCache;
 import com.htmake.htbot.discord.commands.skill.cache.SkillCache;
 import org.springframework.stereotype.Component;
@@ -32,6 +33,9 @@ public class CacheFactory {
     //skill
     public static SkillCache skillCache;
 
+    //quest
+    public static QuestDialogueCache questDialogueCache;
+
     //global
     public static MessageCache messageCache;
 
@@ -48,6 +52,8 @@ public class CacheFactory {
         bossShopCache = new BossShopCache();
 
         skillCache = new SkillCache();
+
+        questDialogueCache = new QuestDialogueCache();
 
         messageCache = new MessageCache();
     }

--- a/src/main/java/com/htmake/htbot/global/custom/interaction/enums/EventType.java
+++ b/src/main/java/com/htmake/htbot/global/custom/interaction/enums/EventType.java
@@ -1,0 +1,6 @@
+package com.htmake.htbot.global.custom.interaction.enums;
+
+public enum EventType {
+
+    SLASH, BUTTON
+}

--- a/src/main/java/com/htmake/htbot/global/custom/interaction/factory/InteractionEventFactory.java
+++ b/src/main/java/com/htmake/htbot/global/custom/interaction/factory/InteractionEventFactory.java
@@ -1,0 +1,18 @@
+package com.htmake.htbot.global.custom.interaction.factory;
+
+import com.htmake.htbot.global.custom.interaction.wrapper.InteractionEventWrapper;
+import com.htmake.htbot.global.custom.interaction.wrapper.impl.ButtonInteractionEventWrapper;
+import com.htmake.htbot.global.custom.interaction.wrapper.impl.SlashCommandInteractionEventWrapper;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+
+public class InteractionEventFactory {
+
+    public static InteractionEventWrapper createWrapper(ButtonInteractionEvent buttonEvent) {
+        return new ButtonInteractionEventWrapper(buttonEvent);
+    }
+
+    public static InteractionEventWrapper createWrapper(SlashCommandInteractionEvent slashCommandEvent) {
+        return new SlashCommandInteractionEventWrapper(slashCommandEvent);
+    }
+}

--- a/src/main/java/com/htmake/htbot/global/custom/interaction/wrapper/InteractionEventExtractor.java
+++ b/src/main/java/com/htmake/htbot/global/custom/interaction/wrapper/InteractionEventExtractor.java
@@ -1,0 +1,42 @@
+package com.htmake.htbot.global.custom.interaction.wrapper;
+
+import com.htmake.htbot.global.custom.interaction.enums.EventType;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+
+public abstract class InteractionEventExtractor<T, R> implements InteractionEventWrapper {
+
+    protected final T event;
+    protected final EventType eventType;
+    protected R reply;
+
+    protected InteractionEventExtractor(T event, EventType eventType) {
+        this.event = event;
+        this.eventType = eventType;
+        this.reply = null;
+    }
+
+    @Override
+    public SlashCommandInteractionEvent getSlashEvent() {
+        return null;
+    }
+
+    @Override
+    public ButtonInteractionEvent getButtonEvent() {
+        return null;
+    }
+
+    @Override
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    protected abstract R getReplyInstance(MessageEmbed embed);
+
+    @Override
+    public InteractionEventWrapper replyEmbed(MessageEmbed embed) {
+        this.reply = getReplyInstance(embed);
+        return this;
+    }
+}

--- a/src/main/java/com/htmake/htbot/global/custom/interaction/wrapper/InteractionEventWrapper.java
+++ b/src/main/java/com/htmake/htbot/global/custom/interaction/wrapper/InteractionEventWrapper.java
@@ -1,0 +1,27 @@
+package com.htmake.htbot.global.custom.interaction.wrapper;
+
+import com.htmake.htbot.global.custom.interaction.enums.EventType;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.ItemComponent;
+import net.dv8tion.jda.api.interactions.components.LayoutComponent;
+
+import java.util.Collection;
+
+public interface InteractionEventWrapper {
+
+    InteractionEventWrapper replyEmbed(MessageEmbed embed);
+
+    InteractionEventWrapper setComponents(Collection<? extends LayoutComponent> components);
+
+    InteractionEventWrapper setActionRow(ItemComponent... itemComponents);
+
+    void queue();
+
+    EventType getEventType();
+
+    SlashCommandInteractionEvent getSlashEvent();
+
+    ButtonInteractionEvent getButtonEvent();
+}

--- a/src/main/java/com/htmake/htbot/global/custom/interaction/wrapper/impl/ButtonInteractionEventWrapper.java
+++ b/src/main/java/com/htmake/htbot/global/custom/interaction/wrapper/impl/ButtonInteractionEventWrapper.java
@@ -1,0 +1,47 @@
+package com.htmake.htbot.global.custom.interaction.wrapper.impl;
+
+import com.htmake.htbot.global.custom.interaction.enums.EventType;
+import com.htmake.htbot.global.custom.interaction.wrapper.InteractionEventExtractor;
+import com.htmake.htbot.global.custom.interaction.wrapper.InteractionEventWrapper;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.ItemComponent;
+import net.dv8tion.jda.api.interactions.components.LayoutComponent;
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction;
+
+import java.util.Collection;
+
+public class ButtonInteractionEventWrapper extends InteractionEventExtractor<ButtonInteractionEvent, WebhookMessageEditAction<Message>> {
+
+    public ButtonInteractionEventWrapper(ButtonInteractionEvent event) {
+        super(event, EventType.BUTTON);
+    }
+
+    @Override
+    protected WebhookMessageEditAction<Message> getReplyInstance(MessageEmbed embed) {
+        return event.getHook().editOriginalEmbeds(embed);
+    }
+
+    @Override
+    public InteractionEventWrapper setComponents(Collection<? extends LayoutComponent> components) {
+        reply.setComponents(components);
+        return this;
+    }
+
+    @Override
+    public InteractionEventWrapper setActionRow(ItemComponent... itemComponents) {
+        reply.setActionRow(itemComponents);
+        return this;
+    }
+
+    @Override
+    public void queue() {
+        reply.queue();
+    }
+
+    @Override
+    public ButtonInteractionEvent getButtonEvent() {
+        return event;
+    }
+}

--- a/src/main/java/com/htmake/htbot/global/custom/interaction/wrapper/impl/SlashCommandInteractionEventWrapper.java
+++ b/src/main/java/com/htmake/htbot/global/custom/interaction/wrapper/impl/SlashCommandInteractionEventWrapper.java
@@ -1,0 +1,46 @@
+package com.htmake.htbot.global.custom.interaction.wrapper.impl;
+
+import com.htmake.htbot.global.custom.interaction.enums.EventType;
+import com.htmake.htbot.global.custom.interaction.wrapper.InteractionEventExtractor;
+import com.htmake.htbot.global.custom.interaction.wrapper.InteractionEventWrapper;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.ItemComponent;
+import net.dv8tion.jda.api.interactions.components.LayoutComponent;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+
+import java.util.Collection;
+
+public class SlashCommandInteractionEventWrapper extends InteractionEventExtractor<SlashCommandInteractionEvent, ReplyCallbackAction> {
+
+    public SlashCommandInteractionEventWrapper(SlashCommandInteractionEvent event) {
+        super(event, EventType.SLASH);
+    }
+
+    @Override
+    protected ReplyCallbackAction getReplyInstance(MessageEmbed embed) {
+        return event.replyEmbeds(embed);
+    }
+
+    @Override
+    public InteractionEventWrapper setComponents(Collection<? extends LayoutComponent> components) {
+        reply.setComponents(components);
+        return this;
+    }
+
+    @Override
+    public InteractionEventWrapper setActionRow(ItemComponent... itemComponents) {
+        reply.setActionRow(itemComponents);
+        return this;
+    }
+
+    @Override
+    public void queue() {
+        reply.queue();
+    }
+
+    @Override
+    public SlashCommandInteractionEvent getSlashEvent() {
+        return event;
+    }
+}

--- a/src/main/java/com/htmake/htbot/global/generics/LimitedCapacityDeque.java
+++ b/src/main/java/com/htmake/htbot/global/generics/LimitedCapacityDeque.java
@@ -1,0 +1,70 @@
+package com.htmake.htbot.global.generics;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+public class LimitedCapacityDeque<T> {
+
+    private final Deque<T> deque;
+    private final Integer maxSize;
+
+    public LimitedCapacityDeque() {
+        this.deque = new ArrayDeque<>();
+        this.maxSize = null;
+    }
+
+    public LimitedCapacityDeque(int maxSize) {
+        this.deque = new ArrayDeque<>();
+
+        if (maxSize < 1) {
+            throw new RuntimeException("Size cannot be less than 1. Your size is " + maxSize);
+        }
+
+        this.maxSize = maxSize;
+    }
+
+    public void addFirst(T element) {
+        if (maxSize != null && deque.size() >= maxSize) {
+            deque.removeLast();
+        }
+
+        deque.addFirst(element);
+    }
+
+    public void addLast(T element) {
+        if (maxSize != null && deque.size() >= maxSize) {
+            deque.removeFirst();
+        }
+        deque.addLast(element);
+    }
+
+    public void removeFirst() {
+        deque.removeFirst();
+    }
+
+    public void removeLast() {
+        deque.removeLast();
+    }
+
+    public T getFirst() {
+        return deque.getFirst();
+    }
+
+    public T getLast() {
+        return deque.getLast();
+    }
+
+    public List<T> findAll() {
+        return new ArrayList<>(deque);
+    }
+
+    public int size() {
+        return deque.size();
+    }
+
+    public Integer maxSize() {
+        return maxSize;
+    }
+}

--- a/src/main/java/com/htmake/htbot/global/unirest/HttpClient.java
+++ b/src/main/java/com/htmake/htbot/global/unirest/HttpClient.java
@@ -1,5 +1,7 @@
 package com.htmake.htbot.global.unirest;
 
+import com.htmake.htbot.global.unirest.records.RequestParam;
+import com.htmake.htbot.global.unirest.records.RouteParam;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import kotlin.Pair;
@@ -25,6 +27,8 @@ public interface HttpClient {
     HttpResponse<JsonNode> sendGetRequest(String endPoint, Pair<String, String> firstRouteParam, Pair<String, String> secondRouteParam);
 
     HttpResponse<JsonNode> sendGetRequest(String endPoint, List<Pair<String, String>> requestParamList);
+
+    HttpResponse<JsonNode> sendGetRequest(String endPoint, RouteParam routeParam, RequestParam requestParam);
 
     HttpResponse<JsonNode> sendPatchRequest(String endPoint, Pair<String, String> routeParam, String requestBody);
 

--- a/src/main/java/com/htmake/htbot/global/unirest/impl/HttpClientImpl.java
+++ b/src/main/java/com/htmake/htbot/global/unirest/impl/HttpClientImpl.java
@@ -1,5 +1,7 @@
 package com.htmake.htbot.global.unirest.impl;
 
+import com.htmake.htbot.global.unirest.records.RequestParam;
+import com.htmake.htbot.global.unirest.records.RouteParam;
 import com.htmake.htbot.global.util.RestServiceType;
 import com.htmake.htbot.global.unirest.HttpClient;
 import com.mashape.unirest.http.HttpResponse;
@@ -112,6 +114,19 @@ public class HttpClientImpl implements HttpClient {
             }
 
             return getRequest.asJson();
+        } catch (UnirestException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to send HTTP GET request", e);
+        }
+    }
+
+    @Override
+    public HttpResponse<JsonNode> sendGetRequest(String endPoint, RouteParam routeParam, RequestParam requestParam) {
+        try {
+            return Unirest.get(RestServiceType.DEFAULT_URL + endPoint)
+                    .routeParam(routeParam.name(), routeParam.value())
+                    .queryString(requestParam.name(), requestParam.value())
+                    .asJson();
         } catch (UnirestException e) {
             e.printStackTrace();
             throw new RuntimeException("Failed to send HTTP GET request", e);

--- a/src/main/java/com/htmake/htbot/global/unirest/records/RequestParam.java
+++ b/src/main/java/com/htmake/htbot/global/unirest/records/RequestParam.java
@@ -1,0 +1,4 @@
+package com.htmake.htbot.global.unirest.records;
+
+public record RequestParam(String name, String value) {
+}

--- a/src/main/java/com/htmake/htbot/global/unirest/records/RouteParam.java
+++ b/src/main/java/com/htmake/htbot/global/unirest/records/RouteParam.java
@@ -1,0 +1,4 @@
+package com.htmake.htbot.global.unirest.records;
+
+public record RouteParam(String name, String value) {
+}


### PR DESCRIPTION
- 퀘스트 진행 전, 후에 스토리 대화를 보여주는 기능 구현
- button event와 slash event의 replyEmbeds()를 구분해서 사용하기 불편해서 wrapper를 만들어서 합쳤다
- 기존 quest event 들을 action과 event로 나눠서 기능을 확실하게 함